### PR TITLE
Ajoute un path alias TypeScript `@/` ==>  `./src`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7397,6 +7397,10 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@marsai/database": "*"
+      },
+      "devDependencies": {
+        "tsc-alias": "^1.8.16",
+        "typescript": "^5.9.3"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1899,6 +1899,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -3297,6 +3307,19 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -3968,6 +3991,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4155,6 +4199,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
@@ -4835,6 +4889,20 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mylas": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.14.tgz",
+      "integrity": "sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/raouldeheer"
+      }
+    },
     "node_modules/mysql2": {
       "version": "3.15.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
@@ -5196,6 +5264,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -5305,6 +5383,19 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/plimit-lit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "queue-lit": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/points-on-curve": {
@@ -5783,6 +5874,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-lit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/queue-microtask": {
@@ -6324,6 +6425,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -6823,6 +6934,38 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tsc-alias": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.16.tgz",
+      "integrity": "sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "get-tsconfig": "^4.10.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
+      },
+      "bin": {
+        "tsc-alias": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -7206,6 +7349,7 @@
         "@types/express": "^5.0.6",
         "@types/node": "^24.10.12",
         "nodemon": "^3.1.11",
+        "tsc-alias": "^1.8.16",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@marsai/root",
   "private": true,
-  "workspaces": ["packages/database", "packages/backend", "packages/frontend"],
+  "workspaces": [
+    "packages/database",
+    "packages/backend",
+    "packages/frontend"
+  ],
   "engines": {
     "node": ">=24"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "db:migrate": "npm run migrate -w @marsai/database",
     "db:generate": "npm run generate -w @marsai/database",
     "db:studio": "npm run studio -w @marsai/database",
-    "db:seed": "npm run db:seed -w @marsai/database"
+    "db:seed": "npm run db:seed -w @marsai/database",
+    "build": "npm run build --workspaces --if-present",
+    "type-check": "npm run type-check --workspaces --if-present",
+    "test": "npm run test --workspaces --if-present"
   },
   "description": "An AI film festival application",
   "homepage": "https://github.com/ebouchut/mars-ai-project#readme",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "dev": "nodemon",
     "start": "node dist/app.js",
-    "build": "tsc",
+    "build": "tsc && tsc-alias",
     "type-check": "tsc --noEmit",
     "test": "echo \"TODO\" && exit 1"
   },
@@ -35,6 +35,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^24.10.12",
     "nodemon": "^3.1.11",
+    "tsc-alias": "^1.8.16",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   }

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -8,6 +8,16 @@
     // Directory where compiled .js files are emitted
     "outDir":  "./dist",
 
+    // Base directory for resolving path aliases
+    "baseUrl": "./src",
+
+    // Path aliases: @/ maps to the src/ directory
+    // @/common/utils/hash.js ==> {baseUrl}}/common/utils/hash.js.
+    // @/common/utils/hash.js ==> ./src/common/utils/hash.js.
+    "paths": {
+      "@/*": ["./*"]
+    },
+
     // ~~~~~ Environment Settings
     // Combined with `"type": "module"` in a local package.json,
     // this enforces including file extensions on relative path imports.

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -13,7 +13,10 @@
     "studio": "prisma studio",
     "db:pull": "prisma db pull",
     "db:push": "prisma db push",
-    "db:seed": "prisma db seed"
+    "db:seed": "prisma db seed",
+    "build": "tsc && tsc-alias",
+    "type-check": "tsc --noEmit",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
     "@prisma/adapter-mariadb": "^7.3.0",

--- a/packages/database/tsconfig.json
+++ b/packages/database/tsconfig.json
@@ -61,5 +61,6 @@
     "moduleDetection": "force",
     // Skip type checking of declaration files
     "skipLibCheck": true
-  }
+  },
+  "include": [ "src" ]
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -13,7 +13,7 @@
   },
   "main": "dist/main.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc-alias",
     "type-check": "tsc --noEmit",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -23,5 +23,9 @@
   "type": "module",
   "dependencies": {
     "@marsai/database": "*"
+  },
+  "devDependencies": {
+    "tsc-alias": "^1.8.16",
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/frontend/src/main.ts
+++ b/packages/frontend/src/main.ts
@@ -1,0 +1,1 @@
+// src/main.ts


### PR DESCRIPTION
Cette Pull Request ajoute:

- un **path alias** dans la configuration _TypeScript_ des workspaces `npm` (`@marsai/frontend`, `@marsai/backend`) où `@/` mappé à `./src`.  
  Par exemple dans le backend :  
  Au lieu de :
  ```js
  import { hashPassword, verifyPassword } from "../../../common/utils/hash.js";
  ```
  On peut désormais utiliser cette notation canonique quel que soit l'emplacement du fichier qui importe `hash.js` :  
  ```js
  import { hashPassword, verifyPassword } from "@/common/utils/hash.js";
  ```
- des scripts npm pour lancer dans tous les workspaces (depuis la racine du projet) :
    - la vérification du **typage** (Typescript): `npm run type-check`
    - la **compilation**: `npm run build`
    - les **tests:** `npm run test`
