### PR TITLE
feat(seed): Secure admin password hashing with Argon2id

### DIFF
--- a/packages/database/.env.example
+++ b/packages/database/.env.example
@@ -42,3 +42,10 @@ SHADOW_DATABASE_URL=mysql://TODO_USERNAME_HERE:TODO_PASSWORD_HERE@localhost:3306
 #
 SERVER_PORT=3000
 NODE_ENV=dev
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Database Seeding Configuration
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Password for the admin user account (not database user) created during seeding
+ADMIN_USER_PASSWORD=admin

--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -30,27 +30,17 @@ async function hashPassword(password: string): Promise<string> {
     return `${salt.toString("hex")}:${hash.toString("hex")}`;
 }
 
-const admins = [
-    {
-        email: "admin@marsai.example.com",
-        passwordHash: "TODO:TODO",
-        role: UserRole.admin,
-        firstName: "Admin1",
-        lastName: "Admin",
-    }
-];
-
 async function main() {
-    for (const admin of admins) {
-        const hashedPassword = await hashPassword(admin.passwordHash);
-        await prisma.user.create({
-            data: {
-                ...admin,
-                passwordHash: hashedPassword
-            }
-        });
-    }
-    console.log(`Seeded ${admins.length} admins`);
+    await prisma.user.create({
+        data: {
+            email: "admin@marsai.example.com",
+            passwordHash: await hashPassword("TODO:TODO"),
+            role: UserRole.admin,
+            firstName: "Admin1",
+            lastName: "Admin",
+        }
+    });
+    console.log("Seeded 1 admin");
 }
 
 main()

--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -31,10 +31,15 @@ async function hashPassword(password: string): Promise<string> {
 }
 
 async function main() {
+    const adminPassword = process.env.ADMIN_USER_PASSWORD;
+    if (!adminPassword) {
+        throw new Error("ADMIN_USER_PASSWORD environment variable is required");
+    }
+
     await prisma.user.create({
         data: {
             email: "admin@marsai.example.com",
-            passwordHash: await hashPassword("TODO:TODO"),
+            passwordHash: await hashPassword(adminPassword),
             role: UserRole.admin,
             firstName: "Admin1",
             lastName: "Admin",

--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -1,4 +1,6 @@
 import "dotenv/config";
+import { argon2, randomBytes } from "node:crypto";
+import { promisify } from "node:util";
 import { PrismaMariaDb } from "@prisma/adapter-mariadb"
 import { PrismaClient, UserRole } from "../src/generated/prisma/client.js"
 
@@ -7,6 +9,26 @@ const adapter = new PrismaMariaDb(process.env.DATABASE_URL!);
 const prisma = new PrismaClient({
     adapter,
 });
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Hash password using Argon2id (OWASP recommended parameters)
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const argon2Async = promisify(argon2);
+
+async function hashPassword(password: string): Promise<string> {
+    const salt = randomBytes(16); // 128-bit salt
+
+    const hash = await argon2Async("argon2id", {
+        message: password,
+        nonce: salt,
+        parallelism: 1,
+        memory: 47104, // 46 MiB
+        passes: 1,
+        tagLength: 32, // 256-bit hash
+    });
+
+    return `${salt.toString("hex")}:${hash.toString("hex")}`;
+}
 
 const admins = [
     {
@@ -20,7 +42,13 @@ const admins = [
 
 async function main() {
     for (const admin of admins) {
-        await prisma.user.create({ data: admin });
+        const hashedPassword = await hashPassword(admin.passwordHash);
+        await prisma.user.create({
+            data: {
+                ...admin,
+                passwordHash: hashedPassword
+            }
+        });
     }
     console.log(`Seeded ${admins.length} admins`);
 }


### PR DESCRIPTION
**TLDR;**  
> This PR updates the script that seeds the database with the admin user ([`packages/database/prisma/seed.ts`](https://github.com/ebouchut/mars-ai-project/blob/dev/packages/database/prisma/seed.ts)) to hash the password using _Argon2id_ (the _Argon2_ hash algorithm, with `id` variant).  
> 
> The **cleartext** admin password should now be defined in `ADMIN_USER_PASSWORD` in [`packages/database/.env`](https://github.com/ebouchut/mars-ai-project/blob/dev/packages/database/.env).
>
> To prevent introducing a cyclic dependency, this script (in the `database` npm workspace) does not use the hash module available from the `backend`, but `argon2` available in the Node.js version (24+)   and uses the same configuration as this module (Memory: 46 MiB, salt: 128-bit (16 bytes), tag: 256-bit (32 bytes).

## Overview

- Use _Argon2id_ password hashing for admin seed password
- Add secure password hashing with recommended _OWASP_ parameters
- Introduce `ADMIN_USER_PASSWORD` environment variable for seeding
- Simplify Admin seeding process

## Security Improvements

- Use _Argon2id_ algorithm for password hashing (See #18 and #43)
- Generate salt (16 bytes = 128-bit)
- Compute 256-bit (32 bytes) tag with conservative memory/parallelism settings (Memory: 46 MiB)
- Replace plaintext password storage with secure hash
