### PR TITLE
L'exécution des tests avec `npm run test` est désormais non-bloquante

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "db:seed": "npm run db:seed -w @marsai/database",
     "build": "npm run build --workspaces --if-present",
     "type-check": "npm run type-check --workspaces --if-present",
-    "test": "npm run test --workspaces --if-present"
+    "test": "npm run test:run --workspaces --if-present"
   },
   "description": "An AI film festival application",
   "homepage": "https://github.com/ebouchut/mars-ai-project#readme",


### PR DESCRIPTION
Cette PR rend l'exécution des tests avec `npm run test` **NON** bloquante.