### PR TITLE
Add a bug report  GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,93 @@
+---
+name: "\U0001F41B Bug report"
+about: Create a report to help us fix things
+title: ''
+labels: ['needs-triage']
+type: "bug"
+assignees: ''
+projects: ['ebouchut/9']
+---
+
+## Description
+
+> 🇬🇧🇺🇸
+> A clear and concise description of what the bug is. 
+> Describe what you see versus what you expect to see.
+
+> 🇫🇷
+> Donnez une description claire et concise du bug.
+> Décrivez ce que vous voyez par rapport à ce que vous vous attendiez à voir.
+
+
+## Log
+
+## How to Reproduce
+
+> 🇬🇧🇺🇸
+> Steps to reproduce the behavior:
+> 1. Go to `...`
+> 2. Click on `....`
+> 3. Scroll down to `....`
+> 4. See error
+
+> 🇫🇷
+> Voici les étapes pour reproduire ce problème :
+1. Allez dans  `...`,
+2. Cliquez sur `...`,
+3. Faites défiler vers le bas jusqu'à `...`,
+4. L'erreur apparaît.
+
+
+## Expected behavior
+
+> 🇬🇧🇺🇸
+> A clear and concise description of what you expected to happen.*
+
+> 🇫🇷
+> **Comportement attendu**:
+> Une description claire et concise de ce à quoi vous vous attendiez.
+
+## Screenshots
+
+> 🇬🇧🇺🇸
+> If applicable, add screenshots to help explain your problem.
+
+> 🇫🇷
+> Si nécessaire, ajoutez des **captures d'écran** pour illustrer le problème que vous rencontrez.
+
+## Setup Information (please complete the following information):
+
+> 🇬🇧🇺🇸
+> From the project root folder:
+>
+> * **Node version**: Output of `node --version`
+> * **Npm version**: Output of `npm --version`
+> * **Installed npm packages**: Output of `npm list`
+> * **Git Reference**: Output of `git rev-parse HEAD`
+
+> 🇫🇷 
+> Informations de **configuration** (à compléter). 
+> Depuis le dossier racine de votre projet :
+>
+> * **Version de Node** : résultat de la commande `node --version`
+> * **Version de Npm** : résultat de la commande `npm --version`
+> * **Packages Npm installés** : résultat de la commande `npm list`
+> * **Référence Git** (SHA du commit) : résultat de la commande `git rev-parse HEAD`
+
+## Technical Details
+
+> 🇬🇧🇺🇸
+> If applicable, provide any technical details that might help in diagnosing the problem. 
+> This could include logs, error messages, or relevant configuration details.
+
+> 🇫🇷
+> Tous les **détails techniques** susceptibles de nous **aider à diagnostiquer** le problème.
+> Il peut s'agir de fichiers de log, de messages d'erreur ou de détails de configuration pertinents.
+
+## Additional context
+
+> 🇬🇧🇺🇸
+> Add any other context about the problem here.
+
+> 🇫🇷
+> Ajoutez ici tout autre **contexte** concernant le problème.


### PR DESCRIPTION
Create a bug report template with sections in
English and French to improve issue reporting clarity and
provide a structured approach for users to submit bugs.