### PR TITLE
Ajout du code de conduite (Code of Conduct) en Anglais et Français 

### DIFF
--- a/CODE_OF_CONDUCT-fr.md
+++ b/CODE_OF_CONDUCT-fr.md
@@ -1,0 +1,90 @@
+
+# Code de conduite _Contributor Covenant_
+
+Ceci est la version française du code de conduite de ce projet.  
+🇺🇸🇬🇧La [version Anglaise se trouve ici](CODE_OF_CONDUCT.md).
+
+## Notre engagement
+
+En tant que membres, contributeur·trice·s et dirigeant·e·s, nous nous engageons à faire de la participation à notre communauté une expérience sans harcèlement, quel que soit l'âge, la taille, le handicap visible ou non, l'ethnicité, les caractéristiques sexuelles, l'identité et l'expression de genre, le niveau d'expérience, l'éducation, le statut socio-économique, la nationalité, l'apparence, la race, la caste, la couleur de peau, la religion, ou l'identité et l'orientation sexuelle.
+
+Nous nous engageons à agir et interagir de manière à contribuer à une communauté ouverte, accueillante, diversifiée, inclusive et saine.
+
+## Nos critères
+
+Exemples de comportements qui contribuent à créer un environnement positif :
+
+* Faire preuve d'empathie et de bienveillance envers les autres
+* Être respectueux des opinions, points de vue et expériences divergents
+* Donner et recevoir avec grâce les critiques constructives
+* Assumer ses responsabilités et s'excuser auprès des personnes affectées par nos erreurs et apprendre de ces expériences
+* Se concentrer sur ce qui est le meilleur non pas uniquement pour nous en tant qu'individu, mais aussi pour l'ensemble de la communauté
+
+Exemples de comportements inacceptables :
+
+* L'utilisation de langage ou d'images sexualisés et d'attentions ou d'avances sexuelles de toute nature
+* Le _trolling_, les commentaires insultants ou désobligeants et les attaques personnelles ou d'ordre politique
+* Le harcèlement en public ou en privé
+* La publication d'informations privées d'autrui, telle qu'une adresse postale ou une adresse électronique, sans leur autorisation explicite
+* Toute autre conduite qui pourrait raisonnablement être considérée comme inappropriée dans un cadre professionnel
+
+## Responsabilités d'application
+
+Les dirigeant·e·s de la communauté sont chargé·e·s de clarifier et de faire respecter nos normes de comportements acceptables et prendront des mesures correctives appropriées et équitables en réponse à tout comportement qu'ils ou elles jugent inapproprié, menaçant, offensant ou nuisible.
+
+Les dirigeant·e·s de la communauté ont le droit et la responsabilité de supprimer, modifier ou rejeter les commentaires, les contributions, le code, les modifications de wikis, les rapports d'incidents ou de bogues et autres contributions qui ne sont pas alignés sur ce code de conduite, et communiqueront les raisons des décisions de modération le cas échéant.
+
+## Portée d'application
+
+Ce code de conduite s'applique à la fois au sein des espaces du projet ainsi que dans les espaces publics lorsqu'un individu représente officiellement le projet ou sa communauté. Font parties des exemples de représentation d'un projet ou d'une communauté l'utilisation d'une adresse électronique officielle, la publication sur les réseaux sociaux à l'aide d'un compte officiel ou le fait d'agir en tant que représentant·e désigné·e lors d'un événement en ligne ou hors-ligne.
+
+## Application
+
+Les cas de comportements abusifs, harcelants ou tout autre comportement inacceptables peuvent être signalés aux dirigeant·e·s de la communauté responsables de l'application du code de conduite à eric.bouchut@laplateforme.io.
+Toutes les plaintes seront examinées et feront l'objet d'une enquête rapide et équitable.
+
+Tou·te·s les dirigeant·e·s de la communauté sont tenu·e·s de respecter la vie privée et la sécurité des personnes ayant signalé un incident.
+
+## Directives d'application
+
+Les dirigeant·e·s de communauté suivront ces directives d'application sur l'impact communautaire afin de déterminer les conséquences de toute action qu'ils jugent contraire au présent code de conduite :
+
+### 1. Correction
+
+**Impact communautaire** : utilisation d'un langage inapproprié ou tout autre comportement jugé non professionnel ou indésirable dans la communauté.
+
+**Conséquence** : un avertissement écrit et privé de la part des dirigeant·e·s de la communauté, clarifiant la nature du non-respect et expliquant pourquoi le comportement était inapproprié. Des excuses publiques peuvent être demandées.
+
+### 2. Avertissement
+
+**Impact communautaire** : un non-respect par un seul incident ou une série d'actions.
+
+**Conséquence** : un avertissement avec des conséquences dû à la poursuite du comportement. Aucune interaction avec les personnes concernées, y compris l'interaction non sollicitée avec celles et ceux qui sont chargé·e·s de l'application de ce code de conduite, pendant une période déterminée. Cela comprend le fait d'éviter les interactions dans les espaces communautaires ainsi que sur les canaux externes comme les médias sociaux. Le non-respect de ces conditions peut entraîner un bannissement temporaire ou permanent.
+
+### 3. Bannissement temporaire
+
+**Impact communautaire** : un non-respect grave des normes communautaires, notamment un comportement inapproprié soutenu.
+
+**Conséquence** : un bannissement temporaire de toutes formes d'interactions ou de communications avec la communauté pendant une période déterminée. Aucune interaction publique ou privée avec les personnes concernées, y compris les interactions non sollicitées avec celles et ceux qui appliquent ce code de conduite, n'est autorisée pendant cette période. Le non-respect de ces conditions peut entraîner un bannissement permanent.
+
+### 4. Bannissement permanent
+
+**Impact communautaire** : démontrer un schéma récurrent de non-respect des normes de la communauté y compris un comportement inapproprié soutenu, le harcèlement d'un individu ainsi que l'agression ou le dénigrement de catégories d'individus.
+
+**Conséquence** : un bannissement permanent de toutes formes d'interactions publiques au sein de la communauté.
+
+## Attributions
+
+Ce code de conduite est adapté du [Contributor Covenant][homepage], version 2.1,
+disponible à [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Les Directives d'application ont été inspirées par le [Code of conduct enforcement ladder][Mozilla CoC] de Mozilla.
+
+Pour obtenir des réponses aux questions courantes sur ce code de conduite, consultez la FAQ à [https://www.contributor-covenant.org/faq][FAQ]. Les traductions sont disponibles sur [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,95 @@
+
+# Contributor Covenant 3.0 Code of Conduct
+
+This is the _English_ version of the project **Code of Conduct**.  
+🇫🇷[**Version française du Code de conduite**](CODE_OF_CONDUCT-fr.md) A French version of the Code of Conduct [can be found here](CODE_OF_CONDUCT-fr.md).
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, **send an email to eric.bouchut@laplateforme.io .**
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+****
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,10 +275,12 @@ gitGraph
     branch feat/add-home-page
     checkout feat/add-home-page
     commit
+    commit
     checkout dev
     merge feat/add-home-page
 
     branch feat/add-footer
+    commit
     commit
     checkout dev
     merge feat/add-footer
@@ -469,6 +471,7 @@ npm test -w @marsai/frontend
   ```
 
 ### Running the CI Locally
+
 
 
 ## Submitting Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,11 +57,10 @@ We use a **monorepo**, that is a Git repository containing both the **frontend a
 
 #### Directory Structure
 
-The project is composed of **3 `npm` packages. 
-These are scoped below the `@marsai` `npm` workspace:
+The project is composed of 3 `npm` packages scoped below the `@marsai` `npm` workspace:
 
 - **`@marsai/database`**: Database schema and generated JavaScript code
-  (database ORM client, and types mainly model JS objects) (in `packages/database`)
+  (database ORM client (query API), and types (models, enums) JS objects) (in `packages/database`)
 - **`@marsai/backend`**:  Node/Express app (in `packages/backend`)
 - **`@marsai/frontend`**: React app (in `packages/frontend`)
 
@@ -205,7 +204,6 @@ The **Entity Relationships Diagram** (ERD) is available as:
 
 ### Reporting Bugs
 
-#### Bug Report Template
 
 ### Suggesting Enhancements
 
@@ -328,8 +326,8 @@ Here is the **workflow** to add/update/remove the database structure (table, tab
 1. Generate the SQL migration file and apply it to the database:
    ```shell
    # cd mars-ai-project
-   npm run db:migrate dev --name add-email-verified-at-to-users
-
+    npm run migrate  -w @marsai/database -- --name add-email-verified-at-to-users
+   
    # same as
    # npm run prisma migrate dev --name add-email-verified-at-to-users -w @marsai/database
    ```
@@ -364,13 +362,14 @@ Here is the **workflow** to add/update/remove the database structure (table, tab
 > This ensures the database schema and the code to query and model entities remain in sync.
 
 
-A _backend_ need to import both the ORM **client** and the models (types).
+The **backend** imports both the ORM **client** and the models (types):
 ```ts
 import { PrismaClient }           from "@marsai/database/client";
 import { User, Vote, Film, Jury } from "@marsai/database";
 ```
 
-The _frontend_ **only** need to import **the models** (types) because it does not interact with the database
+The **frontend** **only** imports **the models** (types).  
+It does not need the client because it does not interact with the database.
 ```ts
 import { User, Vote, Film, Jury } from "@marsai/database";
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ If you have any questions, feel free to
 
 ### Code of Conduct
 
+Make sure you read and agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ### Prerequisites for Development
 
 Read the [Prerequisites section of the README](README.md#prerequisites).
@@ -273,12 +275,10 @@ gitGraph
     branch feat/add-home-page
     checkout feat/add-home-page
     commit
-    commit
     checkout dev
     merge feat/add-home-page
 
     branch feat/add-footer
-    commit
     commit
     checkout dev
     merge feat/add-footer
@@ -469,7 +469,6 @@ npm test -w @marsai/frontend
   ```
 
 ### Running the CI Locally
-
 
 
 ## Submitting Changes


### PR DESCRIPTION
Cette PR :

- ajoute un code de conduite bilingue (anglais, français) basé sur [Contributor Covenant](https://www.contributor-covenant.org/),
- met à jour `CONTRIBUTING.md` pour faire référence au nouveau code de conduite,
- corrige les coquilles dans `CONTRIBUTING.md`.