### PR TITLE
Ajout de scripts `npm` pour remettre à zéro la base de données, lui appliquer les migrations, la peupler 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,25 +301,30 @@ gitGraph
 
 ### Code Style and Formatting
 
+
 ### Reset the Development Database
 
 This section explains how to reset the development database.
 It may prove useful when you need to start from a blank slate.
 
 > [!WARNING]
-> Think twice before launching this command because it will **remove all data from your database**.
+> Think twice before launching this command because it will **remove all the data in your database**.
 
 ```shell
-# You will lose all data in your database!
-npx -w @marsai/database prisma migrate reset
-npx -w @marsai/database prisma db      seed
+# Running this command will DELETE ALL the DATA in your database!
+npx db:reset
+
+# Shortcut for:
+# npx -w @marsai/database prisma migrate reset
+# npx -w @marsai/database prisma db      seed
 ```
 
-These commands:
+This command:
 
-1. drops the database structure (deletes all the tables...)
+1. drops the recreates the database schema that is the structure (tables...)
 1. applies all database migrations in order to recreate the database structure
 1. runs the [seed script](./packages/database/prisma/seed.ts) to populate the database
+
 
 ### Apply the Latest Database Migrations
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
   "scripts": {
     "dev:backend": "npm run dev -w @marsai/backend",
     "dev:frontend": "npm run dev -w @marsai/frontend",
-    "db:migrate": "npm run migrate -w @marsai/database",
+    "db:migrate": "npx -w @marsai/database prisma migrate dev",
     "db:generate": "npm run generate -w @marsai/database",
     "db:studio": "npm run studio -w @marsai/database",
+    "db:reset": "npx -w @marsai/database db:reset",
     "db:seed": "npm run db:seed -w @marsai/database",
     "build": "npm run build --workspaces --if-present",
     "type-check": "npm run type-check --workspaces --if-present",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -13,6 +13,7 @@
     "studio": "prisma studio",
     "db:pull": "prisma db pull",
     "db:push": "prisma db push",
+    "db:reset": "prisma migrate reset && prisma db seed",
     "db:seed": "prisma db seed",
     "build": "tsc && tsc-alias",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
Cette PR:

- ajoute des scripts `npm` au workspace:
    -  **`db:reset`** permet en une seule commande de réinitialiser puis peupler la base de données, c'est-à-dire:
        - vider la base de données en réinitialisant son schéma (structure), 
        - lui appliquer les migrations,
        - la peupler avec des données initiales (_seeds_), aujourd'hui l'administrateur.
- met à jour les scripts du package en conséquence.
