### PR TITLE
L'adresse e-mail de l'administrateur inséré lors de l'initialisation de la base de données est présupposée vérifiée.

### DIFF
--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -47,6 +47,7 @@ async function main() {
             role: UserRole.admin,
             firstName: "Admin1",
             lastName: "Admin",
+            emailVerifiedAt: new Date()
         }
     });
     console.log("Seeded 1 admin");


### PR DESCRIPTION
Cette PR modifie le script d'insertion des données initiales (l'administrateur) en base de données (_seeds_).

On assume que l'adresse e-mail de l'administrateur a été vérifiée et marque l'entité insérée comme telle à l'aide du champ `emailVerifiedAt`. 

Cela permet de simuler un compte administrateur pré-configuré dans l'environnement de développement pour éviter le problème de la 🐔 et 🥚 ;-).
