### PR TITLE
Restreint TypeScript à `src/` dans le backend et le frontend

### DIFF
--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "include" : [ "./src" ],
   // Visit https://aka.ms/tsconfig to read more about this file
   "compilerOptions": {
     // ~~~~~ File Layout

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -1,5 +1,6 @@
 {
   // Visit https://aka.ms/tsconfig to read more about this file
+  "include": ["src"],
   "compilerOptions": {
     // ~~~~~ File Layout
 


### PR DESCRIPTION
On sépare les responsabilités.

Le terrain d'action de _TypeScript_  se limite désormais à `src`, tandis que _Vitest_ s'occupe de `tests/`.