### PR TITLE
Documentation du code source avec `typedoc`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,19 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Project stuff
+# marsAI Project
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Prisma generated sources
 # See: https://www.prisma.io/docs/orm/prisma-schema/overview/generators#3-exclude-the-generated-directory-from-version-control
 /src/generated/prisma
 
-
+# Docs
+# Do not commit the (locally) generated documentation.
+# GitHub CI will generate it automatically when tagging a release.
+#
+/docs/code/  # Aggregated doc (database + backend + frontend)
+packages/database/docs/
+packages/backend/docs/
+packages/frontend/docs/
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Non project stuff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,11 @@ Read the [Prerequisites section of the README](README.md#prerequisites).
 
 ### Understanding the Codebase
 
+#### Code Documentation
+
+You will find the code reference documentation here: TODO.
+
+
 #### Architecture Overview
 
 _marsAI_ is a client server application 
@@ -489,6 +494,22 @@ npm test -w @marsai/frontend
   npm run test:ui -w @marsai/backend
   ```
 
+### Generating the Documentation
+
+You can **generate** the code **documentation locally**:
+
+```shell
+npm run docs
+```
+
+To read the docs open **`docs/code/index.html`** in your browser.
+
+> [!NOTE]
+> We do not commit the local documentation to the repository. 
+> It is gitignored.  
+> However, when tagging a new release on GitHub, the CI will generate it automatically on GitHub.  
+
+🔜
 ### Running the CI Locally
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
         "packages/backend",
         "packages/frontend"
       ],
+      "devDependencies": {
+        "typedoc": "^0.28.17"
+      },
       "engines": {
         "node": ">=24"
       }
@@ -691,6 +694,20 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.22.0.tgz",
+      "integrity": "sha512-jMpciqEVUBKE1QwU64S4saNMzpsSza6diNCk4MWAeCxO2+LFi2FIFmL2S0VDLzEJCxuvCbU783xi8Hp/gkM5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.22.0",
+        "@shikijs/langs": "^3.22.0",
+        "@shikijs/themes": "^3.22.0",
+        "@shikijs/types": "^3.22.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
     },
     "node_modules/@hapi/address": {
       "version": "5.1.1",
@@ -1645,6 +1662,55 @@
         "win32"
       ]
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.22.0.tgz",
+      "integrity": "sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.22.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.22.0.tgz",
+      "integrity": "sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.22.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.22.0.tgz",
+      "integrity": "sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.22.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2059,6 +2125,16 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -2156,6 +2232,13 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
@@ -2502,8 +2585,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "Python-2.0",
-      "peer": true
+      "license": "Python-2.0"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -5471,6 +5553,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -5553,6 +5645,13 @@
         "url": "https://github.com/sponsors/wellwelwel"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5616,6 +5715,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/marked": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
@@ -5637,6 +5767,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -6730,6 +6867,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/puppeteer": {
@@ -8028,6 +8175,56 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/typedoc": {
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.17.tgz",
+      "integrity": "sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.17.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -8041,6 +8238,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.3",
@@ -8513,6 +8717,22 @@
       "peer": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     "db:seed": "npm run db:seed -w @marsai/database",
     "build": "npm run build --workspaces --if-present",
     "type-check": "npm run type-check --workspaces --if-present",
-    "test": "npm run test:run --workspaces --if-present"
+    "test": "npm run test:run --workspaces --if-present",
+    "docs": "typedoc",
+    "docs:database": "npm run docs -w @marsai/database",
+    "docs:backend":  "npm run docs -w @marsai/backend",
+    "docs:frontend": "npm run docs -w @marsai/frontend"
   },
   "description": "An AI film festival application",
   "homepage": "https://github.com/ebouchut/mars-ai-project#readme",
@@ -35,5 +39,8 @@
   "type": "module",
   "directories": {
     "doc": "docs"
+  },
+  "devDependencies": {
+    "typedoc": "^0.28.17"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -11,7 +11,6 @@
     "type": "git",
     "url": "git+https://github.com/ebouchut/mars-ai-project.git"
   },
-  "main": "dist/.main.ts",
   "scripts": {
     "dev": "nodemon",
     "start": "node dist/app.js",
@@ -20,7 +19,8 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "docs": "typedoc"
   },
   "keywords": [],
   "author": "A-Team: https://github.com/ebouchut/mars-ai-project?tab=readme-ov-file#authors",
@@ -47,5 +47,11 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   }
 }

--- a/packages/backend/typedoc.json
+++ b/packages/backend/typedoc.json
@@ -1,0 +1,8 @@
+{
+  "name": "@marsai/backend",
+  "entryPointStrategy": "expand",
+  "entryPoints": [
+    "src"
+  ],
+  "out": "docs"
+}

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -3,10 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "exports": {
-    ".":        "./src/generated/prisma/browser.ts",
-    "./client": "./src/generated/prisma/client.js"
-  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev",
@@ -20,7 +16,8 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "docs": "typedoc"
   },
   "dependencies": {
     "@prisma/adapter-mariadb": "^7.3.0",
@@ -36,5 +33,9 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
+  },
+  "exports": {
+    ".":        "./src/generated/prisma/browser.ts",
+    "./client": "./src/generated/prisma/client.ts"
   }
 }

--- a/packages/database/typedoc.json
+++ b/packages/database/typedoc.json
@@ -1,0 +1,9 @@
+{
+  "name": "@marsai/database",
+  "entryPointStrategy": "resolve",
+  "entryPoints": [
+    "src/generated/prisma/client.ts",
+    "src/generated/prisma/browser.ts"
+  ],
+  "out": "docs"
+}

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -11,14 +11,14 @@
     "type": "git",
     "url": "git+https://github.com/ebouchut/mars-ai-project.git"
   },
-  "main": "dist/main.ts",
   "scripts": {
     "build": "tsc && tsc-alias",
     "type-check": "tsc --noEmit",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "docs": "typedoc"
   },
   "keywords": [],
   "author": "A-Team: https://github.com/ebouchut/mars-ai-project?tab=readme-ov-file#authors",
@@ -33,5 +33,11 @@
     "tsc-alias": "^1.8.16",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/generated/prisma/index.ts",
+      "types": "./dist/generated/prisma/index.d.ts"
+    }
   }
 }

--- a/packages/frontend/typedoc.json
+++ b/packages/frontend/typedoc.json
@@ -1,0 +1,8 @@
+{
+  "name": "@marsai/frontend",
+  "entryPointStrategy": "expand",
+  "entryPoints": [
+    "src"
+  ],
+  "out": "docs"
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,9 @@
+{
+  "entryPointStrategy": "packages",
+  "entryPoints": [
+    "packages/database",
+    "packages/backend",
+    "packages/frontend"
+  ],
+  "out": "docs/code"
+}


### PR DESCRIPTION
Cette PR ajoute une dépendance pour générer la documentation (_HTML_) du code de marsAI.

- Installation de **`typedoc`**, une dépendance utilisée en phase de _développement_.  
  à la racine du workspace pour qu'il soit commun  aux 3 packages (`@marsai/database`,  `@marsai/backend`, `@marsai/frontend`).
- Configuration de `typedoc` pour qu'il génère la documentation de chacun de ces packages séparément puis les agrège dans `docs/code/`.
- Création du point d'entrée du backend (`packages/backend/src/index.ts`) qui importe `app.ts`, lance _Express_ sur le port configuré dans `packages/backend/.env`.

## Utilisation

Pour **générer la documentation du code source du projet** (en local), il faut :

1. Lancer cette commande (depuis la racine du projet) :
  ```shell
  npm run docs
  ```
1. Ouvrir **`docs/code/index.html`** depuis votre navigateur Web.