### PR TITLE
Ajout des fichiers `index.ts` manquants

### DIFF
--- a/packages/backend/nodemon.json
+++ b/packages/backend/nodemon.json
@@ -2,5 +2,5 @@
   "watch":  ["src"],
   "ext":    "ts,json",
   "ignore": ["src/**/*.test.ts"],
-  "exec":   "tsx src/app.ts"
+  "exec":   "tsx src/index.ts"
 }

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -3,20 +3,18 @@
 //  Express Test App
 //~~~~~~~~~~~~~~~~~~~~~
 
-import express from 'express';
+import express, {type Express} from 'express';
 
-const APP = express();
+/*** The backend Express App **/
+const app: Express = express();
 
 // REST Endpoints and Routing
 
 // GET / (Home Page)
-APP.get('/', (req, res) => {
+app.get('/', (req, res) => {
     res.send('Hello Express World')
 });
 
 
-APP.listen(3000, () => {
-    console.log('Express Server running on port 3000')
-});
-
+export default app;
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,0 +1,14 @@
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Entry point of the Backend Express application
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+import { config } from "dotenv";
+import app from "@/app.js";
+
+const PORT = process.env.PORT ?? 3000;
+
+// Start the Express app so that it listens on the port configured in `.env`.
+app.listen(PORT, () => {
+    console.log(`Express Server running on port ${PORT}`)
+});
+


### PR DESCRIPTION
Ajout des points d'entrée (`index.ts`) manquants pour les apps backend et frontend.

Refacto du backend pour que `index.ts` soit désormais le point d'entrée de l'app, et lance l'app (Cf. `app.js`) sur le port configuré dans `.env`.