### PR TITLE
Git ignore le répertoire de la doc (`docs/code`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@
 # Do not commit the (locally) generated documentation.
 # GitHub CI will generate it automatically when tagging a release.
 #
-/docs/code/  # Aggregated doc (database + backend + frontend)
+# Aggregated docs (database + backend + frontend)
+/docs/code/
 packages/database/docs/
 packages/backend/docs/
 packages/frontend/docs/


### PR DESCRIPTION
Cette PR corrige une coquille dans `.gitignore` pour ne pas commit la doc générée en local dans `docs/code/`.

- [ ] Configurer la CI GitHub pour qu'elle génère automatiquement la documentation quand on tag une release.