### PR TITLE
Add aliases resolution for test files

### DIFF
--- a/packages/backend/tsconfig.test.json
+++ b/packages/backend/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [ "src", "tests" ],
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  }
+}

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -9,6 +9,15 @@
     // Directory where compiled .js files are emitted
     "outDir":  "./dist",
 
+    // Base directory for resolving path aliases
+    "baseUrl": "./src",
+
+    // Path aliases: @/ maps to the src/ directory
+    // @/components/Button.js ==> ./src/components/Button.js
+    "paths": {
+      "@/*": ["./*"]
+    },
+
     // ~~~~~ Environment Settings
     // Combined with `"type": "module"` in a local package.json,
     // this enforces including file extensions on relative path imports.

--- a/packages/frontend/tsconfig.test.json
+++ b/packages/frontend/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [ "src", "tests" ],
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  }
+}

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+
   test: {
     // Browser-like environment for React components
     // Using happy-dom (faster alternative to jsdom)


### PR DESCRIPTION
This PR fixes `@/` path alias resolution in tests for both _backend_ and _frontend_ packages.

## Why?

Tests importing modules via the `@/` alias were failing because neither TypeScript's compiler nor Vitest's module resolver knew how to expand `@/` to the `src/` directory. 


## What?

This PR fixes `@/` path alias resolution in **tests** for both _backend_ and _frontend_ packages.
Now, test files can use the same import style as source files.


## How?

- Add `tsconfig.test.json` to `packages/backend`, extending the base tsconfig with both `src` and `tests` in scope, enabling path alias resolution during backend test runs.
- Add `tsconfig.test.json` to `packages/frontend` with the same pattern
- Add `@/*` path alias to `packages/frontend/tsconfig.json`
- Configure Vitest in `packages/frontend/vitest.config.ts` to resolve the `@/` alias via `resolve.alias`, ensuring the alias works at both TypeScript compile time **and test runtime**


