### PR TITLE
Correction de l'import de `path` dans  `vitest config.ts`

### DIFF
--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vitest/config';
-import path from 'path';
+import * as path from 'node:path';
 
 export default defineConfig({
   // Resolve path aliases from tsconfig.json

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vitest/config';
-import path from 'path';
+import * as path from 'node:path';
 
 export default defineConfig({
   resolve: {


### PR DESCRIPTION
Correction de `vitest.config.ts` dans le _backend_ et le _frontend_.

Utilisation de `node: protocol`et import namespace de `path`. 