### PR TITLE
Connexion de` i18next` dans le backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5960,6 +5960,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/i18next-fs-backend": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.1.tgz",
+      "integrity": "sha512-eYWTX7QT7kJ0sZyCPK6x1q+R63zvNKv2D6UdbMf15A8vNb2ZLyw4NNNZxPFwXlIv/U+oUtg8SakW6ZgJZcoqHQ==",
+      "license": "MIT"
+    },
+    "node_modules/i18next-http-middleware": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-3.9.2.tgz",
+      "integrity": "sha512-vzd0Z89xR1yF2V2USVS2G6oOzNilTXsBkxQ16GFPGJO4whQI/LIreh4p4Qy7HXQlGrWVp83YaekuG36+t9anJA==",
+      "license": "MIT"
+    },
     "node_modules/i18next-resources-for-ts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/i18next-resources-for-ts/-/i18next-resources-for-ts-2.0.0.tgz",
@@ -10260,6 +10272,8 @@
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "i18next": "^25.8.13",
+        "i18next-fs-backend": "^2.6.1",
+        "i18next-http-middleware": "^3.9.2",
         "joi": "^18.0.2",
         "jsonwebtoken": "^9.0.3",
         "nodemailer": "^8.0.1"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -33,6 +33,8 @@
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "i18next": "^25.8.13",
+    "i18next-fs-backend": "^2.6.1",
+    "i18next-http-middleware": "^3.9.2",
     "joi": "^18.0.2",
     "jsonwebtoken": "^9.0.3",
     "nodemailer": "^8.0.1"

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -5,7 +5,6 @@
 
 import { loadExpress } from '@/loaders/express.js';
 
-const app = loadExpress();
+const app = await loadExpress();
 
 export default app;
-

--- a/packages/backend/src/features/auth/auth.controller.ts
+++ b/packages/backend/src/features/auth/auth.controller.ts
@@ -14,6 +14,6 @@ export async function loginController(req: Request, res: Response): Promise<void
         const result = await login(email, password);
         res.json(result);
     } catch (error) {
-        res.status(401).json({ message: 'Invalid credentials' });
+        res.status(401).json({ message: req.t('auth:invalid_credentials') });
     }
 }

--- a/packages/backend/src/loaders/express.ts
+++ b/packages/backend/src/loaders/express.ts
@@ -1,16 +1,20 @@
 import express, { type Express } from 'express';
-import          { loadRoutes }   from './routes.js';
+import { initI18n }              from './i18n.js';
+import { loadRoutes }            from './routes.js';
 
 /**
  * Creates and configures the Express application.
- * Registers JSON body parsing and all application routes.
+ * Initializes i18n, registers JSON body parsing, and mounts all routes.
  *
  * @returns The configured Express application instance.
  */
-export function loadExpress(): Express {
+export async function loadExpress(): Promise<Express> {
     const app = express();
 
-    // IMPORTANT: app.use() must come before loadRoutes()
+    // Initialize i18next and attach req.t() to every request
+    app.use(await initI18n());
+
+    // IMPORTANT: express.json() must come before loadRoutes()
     // parse req.body as JSON — required before routes
     app.use(express.json());
 

--- a/packages/backend/src/loaders/i18n.ts
+++ b/packages/backend/src/loaders/i18n.ts
@@ -1,0 +1,40 @@
+import i18next          from 'i18next';
+import Backend          from 'i18next-fs-backend';
+import * as middleware  from 'i18next-http-middleware';
+import type { Handler } from 'express';
+
+
+/**
+ * Initializes the `i18next` instance with the filesystem backend
+ * and HTTP language detection middleware.
+ *
+ * - The `fs-backend` plugin loads JSON locale files from disk
+ * - The `http-middleware` plugin detects the language from the `Accept-Language` header
+ * - The supported languages and fallback are configured here
+ *
+ * Must be called before the Express app starts handling requests.
+ *
+ * @returns An Express middleware that attaches `req.t()` to every request.
+ */
+export async function initI18n(): Promise<Handler> {
+    await i18next
+        .use(Backend)  // loads JSON locale files from disk
+        .use(middleware.LanguageDetector) // detects the language from the `Accept-Language` header
+        .init({
+            // Languages the app supports
+            supportedLngs: ['fr', 'en'],
+
+            // Used when the requested language has no translation
+            fallbackLng: 'fr',
+
+            // Namespace that maps to a JSON file (e.g. locales/fr/common.json)
+            defaultNS: 'common',
+
+            backend: {
+                // Path to locale files — points to the shared @marsai/i18n package
+                loadPath: '../../i18n/locales/{{lng}}/{{ns}}.json',
+            },
+        });
+
+    return middleware.handle(i18next);
+}

--- a/packages/i18n/locales/en/auth.json
+++ b/packages/i18n/locales/en/auth.json
@@ -1,0 +1,3 @@
+{
+  "invalid_credentials": "Invalid credentials"
+}

--- a/packages/i18n/locales/fr/auth.json
+++ b/packages/i18n/locales/fr/auth.json
@@ -1,0 +1,3 @@
+{
+  "invalid_credentials": "Identifiants invalides"
+}


### PR DESCRIPTION
Cette PR est la suite de #95.
Elle connecte l'I18N au backend et ajoute la première clé de traduction (Hourra !) :

- ajout des packages `i18next-fs-backend` et `i18next-http-middleware`
- ajout de `src/loaders/i18n.ts` où `i18next` qui est initialisé avec :
        - `18next-fs-backend` qui se chargé de lire les fichiers de traductions
        - `18next-http-middleware` qui assure la détection de langue via l'en-tête HTTP `Accept-Language`
    - renvoie le gestionnaire de middleware Express
- mise à jour de `src/loaders/express.ts` : 
    - appelle `initI18n()` 
    - monte le gestionnaire Express **avant** les routes
- mise à jour de `src/app.ts` : `await async loadExpress()`.  
  Avec l'arrivée du chargement des fichiers de traduction qui est asynchrone, `loadExpress()` doit désormais l'être aussi. 
- mise à jour `auth.controller.ts` : remplacement de la chaîne d'erreur codée en dur par `req.t(“auth:invalid_credentials”)`
- ajout de la clé `invalid_credentials` dans les fichiers de traduction: `packages/i18n/locales/{fr,en}/auth.json`

