### PR TITLE
Ajout des requetes et du guide pour tester l'API backend avec Postman

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,10 @@ such as:`vote.routes.ts`, `vote.controller.ts`, `vote.validation.ts`, and `vote.
 │    │    │   │   └── i18n.ts                Initializes i18next with language detection and locale file loading
 │    │    │   │
 │    │    │   └── app.ts                     Entry point that builds and exports the configured Express app
+│    │    │ 
+│    │    ├── postman/                       Contains the Postman requests to test the REST endpoints
+│    │    │   ├── marsai.environment.json    Postman environment file with placeholders (adjust to your local config.) 
+│    │    │   └── marsai.collection.json     A single collection of Postman requests, with folders per feature  
 │    │    │
 │    │    └── tests/                         Test files mirroring the src/ folder structure
 │    │        └── common/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -343,6 +343,55 @@ The **Entity Relationships Diagram** (ERD) is available as:
 
 ### Setting Up Your Development Environment
 
+### Testing the API with Postman
+
+The repository ships two files under `packages/backend/postman/` that let you
+send requests to the backend API directly from [Postman](https://www.postman.com/):
+
+| File | Purpose |
+|---|---|
+| `marsai.collection.json` | All API requests, grouped by feature |
+| `marsai.environment.json` | Variables with placeholder values (no real credentials) |
+
+#### 1. Import the collection
+
+1. Open Postman.
+2. Click **`Collections`** / **`Import`**.
+3. Select `packages/backend/postman/marsai.collection.json`.
+
+#### 2. Import the environment
+
+1. Click **`Environments`** / **`Import`**.
+2. Select `packages/backend/postman/marsai.environment.json`.
+3. Select **marsAI – Local** as the active environment (top-right dropdown).
+
+#### 3. Configure your local values
+
+Open the **marsAI – Local** environment and fill in the fields marked as placeholders:
+
+| Variable | What to set |
+|---|---|
+| `baseUrl` | URL of your local backend server (default: `http://localhost:3000`) |
+| `loginEmail` | Email of a test account in your local database |
+| `loginPassword` | Password for that account |
+| `authToken` | Leave empty for now — see step 4 |
+
+> [!WARNING]
+> Never commit real credentials. The environment file intentionally ships
+> with empty secret fields (`authToken`, `loginPassword`). Fill them in
+> locally; Postman keeps them on your machine only.
+
+#### 4. Authenticate
+
+Most endpoints require a JWT. To obtain one:
+
+1. Run **`Auth`** / **`Login`** (`POST /auth/login`).
+2. Copy the `token` value from the response body.
+3. Paste it into the `authToken` environment variable.
+
+All subsequent requests that require authentication read `{{authToken}}` from
+the environment automatically.
+
 ### Branching Strategy
 
 > [!NOTE]

--- a/packages/backend/postman/marsai.collection.json
+++ b/packages/backend/postman/marsai.collection.json
@@ -1,0 +1,73 @@
+{
+  "info": {
+    "_comment": [
+      "Postman Collection v2.1 for the marsAI backend REST endpoints.",
+      "",
+      "STRUCTURE:",
+      "  Requests are grouped into folders matching the backend feature modules",
+      "  under packages/backend/src/features/. Add new requests to the folder",
+      "  that matches the feature they belong to.",
+      "",
+      "HOW TO USE:",
+      "  1. Import this file into Postman via Collections → Import.",
+      "  2. Import marsai.environment.json and select it as the active environment.",
+      "  3. Run POST /auth/login first, then copy the token into the",
+      "     'authToken' environment variable for authenticated requests.",
+      "",
+      "CONVENTIONS:",
+      "  - All URLs use the {{baseUrl}} environment variable.",
+      "  - Authenticated requests set 'Authorization: Bearer {{authToken}}'.",
+      "  - Request bodies use JSON."
+    ],
+    "name": "marsAI API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "_comment": "Auth folder — requests matching packages/backend/src/features/auth/",
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Login",
+          "_comment": [
+            "Authenticates a user and returns a JWT.",
+            "On success, copy the token value from the response into the",
+            "'authToken' environment variable to authenticate further requests.",
+            "",
+            "Route:      POST /auth/login",
+            "Validated:  email (string, email format, required)",
+            "            password (string, required)",
+            "Response:   { token: string }  on success",
+            "            { message: string } + 401  on invalid credentials"
+          ],
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/auth/login",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": { "language": "json" }
+              },
+              "raw": "{\n  \"email\": \"{{loginEmail}}\",\n  \"password\": \"{{loginPassword}}\"\n}"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "_comment": "Vote folder — requests matching packages/backend/src/features/vote/",
+      "name": "Vote",
+      "item": [
+        {
+          "_comment": "Placeholder — add requests here as vote endpoints are implemented."
+        }
+      ]
+    }
+  ]
+}

--- a/packages/backend/postman/marsai.environment.json
+++ b/packages/backend/postman/marsai.environment.json
@@ -1,0 +1,48 @@
+{
+  "_comment": [
+    "Postman environment for the marsAI backend API.",
+    "",
+    "HOW TO USE:",
+    "  1. Import this file into Postman via Environments → Import.",
+    "  2. Set 'baseUrl' to your local server (default: http://localhost:3000).",
+    "  3. After a successful POST /auth/login, copy the returned token",
+    "     into the 'authToken' variable so that authenticated requests",
+    "     are pre-filled with the Authorization header.",
+    "",
+    "IMPORTANT — never commit real credentials.",
+    "  The placeholder values below are intentionally empty or fake."
+  ],
+  "id": "marsai-environment",
+  "name": "marsAI – Local",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:3000",
+      "type": "default",
+      "enabled": true,
+      "_comment": "Base URL of the backend server (Express). Change port if needed."
+    },
+    {
+      "key": "authToken",
+      "value": "",
+      "type": "secret",
+      "enabled": true,
+      "_comment": "JWT returned by POST /auth/login. Paste it here after logging in."
+    },
+    {
+      "key": "loginEmail",
+      "value": "user@example.com",
+      "type": "default",
+      "enabled": true,
+      "_comment": "Email used for the login request body. Replace with a real test account."
+    },
+    {
+      "key": "loginPassword",
+      "value": "",
+      "type": "secret",
+      "enabled": true,
+      "_comment": "Password for the login request. Never commit a real value here."
+    }
+  ],
+  "_postman_variable_scope": "environment"
+}


### PR DESCRIPTION
Cette PR:

- ajoute une collection de requêtes Postman  pour tester l'API backend marsAI dans `packages/backend/postman`.
- documente comment importer, configurer et utiliser cette collection dans `CONTRIBUTING.md`

                

