### PR TITLE
fix: read SERVER_PORT from .env instead of PORT

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -6,7 +6,7 @@ import app from "@/app.js";
 
 
 // Port the server listens on. Defaults to 3000 if not set in .env.
-const PORT = process.env.PORT ?? 3000;
+const PORT = process.env.SERVER_PORT ?? 3000;
 
 // Start the Express app so that it listens on the port configured in `.env`.
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary

- Fixes a mismatch between the documented env variable (`SERVER_PORT` in `.env.example`) and what the code actually reads (`process.env.PORT`)
- With the previous code, setting `SERVER_PORT` in `.env` had no effect; the server always defaulted to port `3000`

Closes #47

## Test plan

- [x] Set `SERVER_PORT=4000` in `packages/backend/.env`
- [x] Run `npm run dev:backend` and confirm the server starts on port 4000

🤖 Generated with [Claude Code](https://claude.com/claude-code)