### PR TITLE
fix: rename AmountCurrency enum mapping to amount_currencies

### DIFF
--- a/packages/database/prisma/migrations/20260306000000_rename_amount_currencies_enum/migration.sql
+++ b/packages/database/prisma/migrations/20260306000000_rename_amount_currencies_enum/migration.sql
@@ -1,0 +1,1 @@
+-- Prisma Migrate tracking: rename AmountCurrency enum mapping from 'awards_amount_currency' to 'amount_currencies'

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -286,7 +286,7 @@ enum AmountCurrency {
   USD
   EUR
 
-  @@map("awards_amount_currency")
+  @@map("amount_currencies")
 }
 
 enum FilmStatus {


### PR DESCRIPTION
## Summary

- Renames the Prisma `@@map` value on the `AmountCurrency` enum from `awards_amount_currency` to `amount_currencies`
- Follows the project convention: lowercase, plural, no model-name prefix (same pattern as `users_role`, etc.)
- Adds a migration file; the SQL is a comment-only no-op because MySQL enums are inline column types — no `ALTER TABLE` is needed

Follows up on the review comment in #36.

Closes #37

## Test plan

- [x] Run `npm run migrate -w @marsai/database` (with a valid `.env`) and confirm it applies cleanly
- [x] Run `npm run generate -w @marsai/database` and confirm the Prisma client rebuilds without errors
- [x] Run `npm run type-check` and confirm no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)